### PR TITLE
sci: messages: support tradusci header

### DIFF
--- a/tools/sci/messages_export.py
+++ b/tools/sci/messages_export.py
@@ -11,6 +11,7 @@ import config
 
 MESSAGES_PATTERN = "*.msg"
 SIERRA_MESSAGE_HEADER = b'\x8f\00'
+TRADUSCI_MESSAGE_HEADER = b'\x0f\00'
 SIERRA_CODEPAGE = 'CP437'
 
 
@@ -63,7 +64,7 @@ def messages_export(gamedir, csvdir):
         with open(filename, "rb") as f:
             lob = list(f.read())
 
-        assert bytes(lob[:2]) == SIERRA_MESSAGE_HEADER
+        assert bytes(lob[:2]) in {SIERRA_MESSAGE_HEADER, TRADUSCI_MESSAGE_HEADER}, bytes(lob[:2])
         lob = lob[2:]
         index = 0
         version = read_le(lob, index)

--- a/tools/sci/messages_import.py
+++ b/tools/sci/messages_import.py
@@ -10,6 +10,7 @@ import binascii
 import config
 
 SIERRA_MESSAGE_HEADER = b'\x8f\00'
+TRADUSCI_MESSAGE_HEADER = b'\x0f\00'
 SIERRA_CODEPAGE = 'CP437'
 
 
@@ -24,7 +25,7 @@ def read_le(l, idx):
 
 
 def update_msg(original, entries):
-    assert bytes(original[:2]) == SIERRA_MESSAGE_HEADER
+    assert bytes(original[:2]) in {SIERRA_MESSAGE_HEADER, TRADUSCI_MESSAGE_HEADER}, bytes(original[:2])
     lob = original[2:]
     index = 0
     version = read_le(lob, index)


### PR DESCRIPTION
adds support for [TraduSCI](https://erolfi.wordpress.com/tradusci/) headers
and printing of current parsed file or header for orientation