### PR TITLE
sci: export messages in tradusci format

### DIFF
--- a/tools/sci/resource_archive/loader.py
+++ b/tools/sci/resource_archive/loader.py
@@ -15,7 +15,7 @@ else:
 
 def load_resources(
     base_dir: Union[str, os.PathLike[str]],
-    resmap: Optional[str] = 'RESOURCE.MAP',
+    resmap: Sequence[str] = ('RESOURCE.MAP', 'RESMAP.000'),
     patches: Optional[Iterable[str]] = (),
     patterns: Sequence[str] = ('*',)
 ):
@@ -50,13 +50,16 @@ def load_resources(
                         parsed_files.add(entry.name)
                         yield entry
 
-    if resmap is not None:
+    for rmap in resmap:
         if not RESOURCE_MAP_SUPPORTED:
             print('WARNING: Reading resources from RESOURCE.MAP is skipped because dependecies are missing')
             print('To enable it, please run the following command:\n  pip install git+https://github.com/adventurebrew/pakal.git')
             return
 
-        with sci_resource.open(base_dir / resmap) as archive:
+        resmap_file = base_dir / rmap
+        if not resmap_file.exists():
+            continue
+        with sci_resource.open(resmap_file) as archive:
             for pattern in patterns:
                 for entry in archive.glob(pattern):
                     if entry.name not in parsed_files:

--- a/tools/sci/resource_archive/sci1_resource.py
+++ b/tools/sci/resource_archive/sci1_resource.py
@@ -165,6 +165,17 @@ class SCI1Archive(BaseArchive[SCI1FileEntry]):
             header = res_type.to_bytes(
                 2, signed=False, byteorder='little'
             )
+
+            # Header fixes based on SCIResDump
+            if res_type == 0:
+                header = (res_type | 0x8080).to_bytes(
+                    2, signed=False, byteorder='little'
+                ) + b'\0\0' + struct.pack('<5H3I', 320, 200, 5, 6, 256, 0, 0, 0)
+            elif res_type == 1:
+                header = (res_type | 0x8181).to_bytes(
+                    2, signed=False, byteorder='little'
+                ) + b'\0\0'
+
             if comp_size < decomp_size:
                 if method == 32:
                     decomp_data = decompress_lzs(

--- a/tools/sci/tradusci_export.py
+++ b/tools/sci/tradusci_export.py
@@ -1,0 +1,348 @@
+import argparse
+import struct
+import sys
+
+from sci.resource_archive.loader import load_resources
+
+
+MESSAGE_PATTERNS = ["message.*", "*.msg"]
+SIERRA_CODEPAGE = 'CP437'
+
+PATCH80 = 0x008F
+PATCH = 0x000F
+
+SCI_01 = 0x00000800
+SCI_02_B = 0x00000B00
+SCI_02_C = 0x00000C00
+SCI_02_D = 0x00000D00
+SCI_05 = 0x00000F00
+SCI_06 = 0x00001000
+SCI32_100 = 0x00001300
+
+TRADUSCI_SIGN = b'TraduSCI'    
+TRADUSCI1_SIGN = b'TraduSCI 1.0 di Enrico Rolfi (Endroz)'
+TRADUSCI2_SIGN = b'TraduSCI2 1.1 di Enrico Rolfi (Endroz)'
+
+SIERRA = 0
+OLDTRADUSCI = 1
+TRADUSCI2 = 2
+
+UINT16LE = struct.Struct('<H')
+UINT32LE = struct.Struct('<I')
+
+def read_uint16le(stream):
+    return UINT16LE.unpack(stream.read(UINT16LE.size))[0]
+
+def read_uint32le(stream):
+    return UINT32LE.unpack(stream.read(UINT32LE.size))[0]
+
+def read_until_null(stream):
+    result = bytearray()
+    while True:
+        char = stream.read(1)
+        if not char or char == b'\x00':
+            break
+        result.extend(char)
+    return bytes(result)
+
+
+def escape_quotes(msg):
+    msg = msg.replace('"', '""')
+    return f'"{msg}"'
+
+
+# Based on TraduSCI source code available at https://erolfi.wordpress.com/tradusci/
+def load_msg_file(stream):
+    offset = 0
+    patch_id = read_uint16le(stream)
+
+    if patch_id in {PATCH, PATCH80}:
+        offset = 2
+    
+    stream.seek(offset)
+
+    version_id = read_uint32le(stream)
+    msg_version_tag = version_id
+    comment_pos = None
+    unk_count = None
+    if version_id & 0xFFFFFF00 > SCI_01:
+        comment_pos = read_uint16le(stream)
+    if version_id & 0xFFFFFF00 >= SCI_05:
+        unk_count = read_uint16le(stream)
+    phrases_count = read_uint16le(stream)
+
+    mversion = msg_version_tag & 0xFFFFFF00
+    assert mversion in {SCI_01, SCI_02_B, SCI_02_C, SCI_02_D, SCI_05, SCI_06, SCI32_100}, hex(mversion)
+    if mversion in {SCI_01, SCI_02_B, SCI_02_C, SCI_02_D, SCI_05} and patch_id == PATCH:
+        print(f'WARNING: should not have 0x{PATCH:04X} in header for older SCI version')
+
+    comments = [{} for _ in range(phrases_count)]
+    phrases = [{} for _ in range(phrases_count)]
+    nouns = [0 for _ in range(256)]
+    verbs = [0 for _ in range(256)]
+    conditions = [0 for _ in range(256)]
+    talkers = [0 for _ in range(256)]
+
+    t_count = phrases_count
+    unk_b_count1 = 5
+    unk_b_count2 = 9
+
+    if mversion == SCI_01:
+        unk_b_count1 = 2
+        unk_b_count2 = 2
+    elif mversion in {SCI_02_B, SCI_02_C, SCI_02_D}:
+        unk_b_count2 = 8
+    
+    tradusci2_data_pos = 0
+
+    oldpos = stream.tell()
+    stream.seek((unk_b_count2 + 2) * phrases_count, 1)
+
+    temp_sign = read_until_null(stream)
+
+    tradusci_session = {}
+
+    if temp_sign == TRADUSCI1_SIGN:
+        tradusci_format = OLDTRADUSCI
+        has_comments = stream.read(1)
+        tradusci_session['current_string'] = read_uint16le(stream)
+        tradusci_session['font_size'] = 18
+    elif temp_sign == TRADUSCI2_SIGN:
+        tradusci_format = TRADUSCI2
+        has_comments = stream.read(1)
+        tradusci_session['current_string'] = read_uint16le(stream)
+        tradusci2_data_pos = read_uint32le(stream)
+        tradusci_session['font_size'] = 18
+        if read_uint16le(stream) == 0xF00F:
+            tradusci_session['font_size'] = ord(stream.read(1))
+        tradusci_session['order'] = 0  # ByIndex
+        if read_uint16le(stream) == 0xE00E:
+            tradusci_session['order'] = ord(stream.read(1))
+        tradusci_session['window'] = b''
+        if read_uint16le(stream) == 0xBAAB:
+            tradusci_session['window'] = stream.read(3 + 8)
+
+    elif temp_sign[:8] == TRADUSCI_SIGN:
+        raise ValueError('newer tradusci version')
+    else:
+        tradusci_format = SIERRA
+        tradusci_session['current_string'] = 0
+        tradusci_session['font_size'] = 18
+
+    stream.seek(oldpos)
+
+    for i in range(t_count):
+        phrases[i]['meta'] = stream.read(unk_b_count1)
+
+        jumpvalue = read_uint16le(stream)
+        oldpos = stream.tell()
+
+        stream.seek(offset + jumpvalue)
+
+        if tradusci_format == SIERRA:
+            phrases[i]['string'] = read_until_null(stream)
+
+        else:
+            temp_str = read_until_null(stream)
+            if tradusci_format == TRADUSCI2:
+                jumpvalue = stream.tell()
+                stream.seek(tradusci2_data_pos)
+
+                translated = ord(stream.read(1))
+                if translated:
+                    if tradusci_format == TRADUSCI2:
+                        stream.seek(-1, 1)
+
+                    phrases[i]['string'] = read_until_null(stream)
+                    phrases[i]['translation'] = temp_str
+                else:
+                    phrases[i]['string'] = temp_str
+
+                if tradusci_format == TRADUSCI2:
+                    tradusci2_data_pos = stream.tell()
+
+        if tradusci_format == OLDTRADUSCI:
+            jumpvalue = stream.tell()
+
+        stream.seek(oldpos)
+        phrases[i]['meta'] += stream.read(unk_b_count2 - unk_b_count1)
+
+    if mversion != SCI_01:
+        nouns[0] = 0  # '<generic>'
+        verbs[0] = 0  # '<generic>'
+        conditions[0] = 0  # '<generic>'
+
+    if tradusci_format == TRADUSCI2:
+        talkers[0] = 0  # '<generic>'
+        if tradusci_format == TRADUSCI2:
+            stream.seek(tradusci2_data_pos)
+
+            try:
+                temp_tag = read_uint16le(stream)
+            except struct.error:
+                temp_tag = 0
+
+            if temp_tag == 0xD00D:
+                idx = ord(stream.read(1))
+                while idx != 0:
+                    nouns[idx] = read_until_null(stream)
+                    idx = ord(stream.read(1))
+
+                idx = ord(stream.read(1))
+                while idx != 0:
+                    verbs[idx] = read_until_null(stream)
+                    idx = ord(stream.read(1))
+
+                idx = ord(stream.read(1))
+                while idx != 0:
+                    conditions[idx] = read_until_null(stream)
+                    idx = ord(stream.read(1))
+
+                idx = ord(stream.read(1))
+                while idx != 0:
+                    talkers[idx] = read_until_null(stream)
+                    idx = ord(stream.read(1))
+
+                temp_tag = read_uint16le(stream)
+                if temp_tag != 0xD0D0:
+                    raise ValueError(temp_tag)
+            else:
+                stream.seek(tradusci2_data_pos)
+
+        rewind = stream.tell()
+        if read_until_null(stream) == b'AMAP':
+            raise NotImplementedError('Loaded audio map info was not implemented')
+            # audmap_name = read_until_null(stream)
+            # ushort = read_uint16le(stream)
+            # audmap = {'id': 0, 'size': 0}
+
+            # initoffs = tuple(stream.read(4))
+
+            # for i in range(ushort):
+            #     print(stream.read(7))
+        else:
+            stream.seek(rewind)
+
+        futurebox = stream.read()
+        if futurebox:
+            raise ValueError(futurebox)
+
+    if mversion > SCI_01:
+        stream.seek(4 + offset)
+        jumpvalue = read_uint16le(stream)
+        assert jumpvalue == comment_pos, (jumpvalue, comment_pos)
+        jumpvalue += 6 + offset
+    
+    if tradusci_format == SIERRA:
+        stream.seek(0, 2)
+        has_comments = jumpvalue < stream.tell()
+
+    if has_comments:
+        stream.seek(jumpvalue)
+        if mversion == SCI_01:
+            unk_b_count1 = 2
+            unk_b_count2 = 0
+        elif mversion in {SCI_02_B, SCI_02_C, SCI_02_D}:
+            unk_b_count1 = 0
+            unk_b_count2 = 0
+        else:
+            unk_b_count1 = 0
+            unk_b_count2 = 6
+        
+        for i in range(t_count):
+            comments[i]['meta'] = stream.read(unk_b_count1)
+            comments[i]['string'] = read_until_null(stream)
+
+            comments[i]['meta'] += stream.read(unk_b_count2 - unk_b_count1)
+
+    return mversion, phrases, comments
+
+
+def generate_rows(phrases, comments, mversion, encoding):
+    for phrase, comment in zip(phrases, comments):
+        noun = 0 if mversion == SCI_01 else phrase['meta'][0]
+        verb = 0 if mversion == SCI_01 else phrase['meta'][1]
+        condition = 0 if mversion == SCI_01 else phrase['meta'][2]
+        sequence = 0 if mversion == SCI_01 else phrase['meta'][3]
+        talker = phrase['meta'][0] if mversion == SCI_01 else phrase['meta'][4]
+        padding = phrase['meta'][1:] if mversion == SCI_01 else phrase['meta'][5:]
+        original = phrase.get('string', b'')
+        translation = phrase.get('translation', b'')
+        comment_padding = comment.get('meta', b'')
+        comment_text = comment.get('string', b'')
+        yield (
+            noun,
+            verb,
+            condition,
+            sequence,
+            talker,
+            padding.hex(),
+            escape_quotes(original.decode(**encoding)),
+            escape_quotes(translation.decode(**encoding)),
+            comment_padding.hex(),
+            escape_quotes(comment_text.decode(**encoding)),
+        )
+
+
+def extract_messages(gamedir, output, encoding):
+    filenames = list(load_resources(
+        gamedir,
+        patterns=MESSAGE_PATTERNS,
+        # patches=None,
+    ))
+
+    encoding = {
+        'encoding': encoding,
+        'errors': 'surrogateescape',
+    }
+
+    headers = (
+        'file',
+        'noun',
+        'verb',
+        'condition',
+        'sequence',
+        'talker',
+        'padding',
+        'text',
+        'translation',
+        'comment_padding',
+        'comment_text',
+    )
+
+    with open(output, 'w', encoding='utf-8', errors='surrogateescape') as out:
+        print(*headers, sep='\t', file=out)
+        for fname in filenames:
+            if not (fname.stem.isnumeric() or fname.suffix.lstrip('.').isnumeric()):
+                continue
+            print(f'Loading messages from {fname}', file=sys.stderr)
+            with fname.open('rb') as stream:
+                mversion, phrases, comments = load_msg_file(stream)
+                for info in generate_rows(phrases, comments, mversion, encoding):
+                    print(fname.name, *info, sep='\t', file=out)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='Exports text from messages files (*.msg) to csv file',
+    )
+    parser.add_argument(
+        'gamedir',
+        help='directory containing the game files',
+    )
+    parser.add_argument(
+        '-o',
+        '--output',
+        default='messages.tsv',
+        help='csv file to export the messages to',
+    )
+    parser.add_argument(
+        '-e',
+        '--encoding',
+        default=SIERRA_CODEPAGE,
+        help='codepage to decode the messages',
+    )
+    args = parser.parse_args()
+
+    extract_messages(args.gamedir, args.output, args.encoding)

--- a/tools/sci/tradusci_export.py
+++ b/tools/sci/tradusci_export.py
@@ -183,26 +183,11 @@ def load_msg_file(stream):
                 temp_tag = 0
 
             if temp_tag == 0xD00D:
-                idx = ord(stream.read(1))
-                while idx != 0:
-                    nouns[idx] = read_until_null(stream)
+                for names in (nouns, verbs, conditions, talkers):
                     idx = ord(stream.read(1))
-
-                idx = ord(stream.read(1))
-                while idx != 0:
-                    verbs[idx] = read_until_null(stream)
-                    idx = ord(stream.read(1))
-
-                idx = ord(stream.read(1))
-                while idx != 0:
-                    conditions[idx] = read_until_null(stream)
-                    idx = ord(stream.read(1))
-
-                idx = ord(stream.read(1))
-                while idx != 0:
-                    talkers[idx] = read_until_null(stream)
-                    idx = ord(stream.read(1))
-
+                    while idx != 0:
+                        names[idx] = read_until_null(stream)
+                        idx = ord(stream.read(1))
                 temp_tag = read_uint16le(stream)
                 if temp_tag != 0xD0D0:
                     raise ValueError(temp_tag)

--- a/tools/sci/tradusci_import.py
+++ b/tools/sci/tradusci_import.py
@@ -1,0 +1,174 @@
+import argparse
+import csv
+from itertools import groupby
+import operator
+from pathlib import Path
+import sys
+
+from sci.resource_archive.loader import load_resources
+from sci.tradusci_export import (
+    MESSAGE_PATTERNS,
+    SIERRA_CODEPAGE,
+    PATCH80,
+    PATCH,
+    SCI_01,
+    SCI_02_B,
+    SCI_02_C,
+    SCI_02_D,
+    SCI_05,
+    SCI32_100,
+    UINT16LE,
+    UINT32LE,
+    read_uint16le,
+    read_header,
+)
+
+
+def write_uint16le(num):
+    return UINT16LE.pack(num)
+
+def write_uint32le(num):
+    return UINT32LE.pack(num)
+
+
+# Based on TraduSCI source code available at https://erolfi.wordpress.com/tradusci/
+def save_msg_file(header, lines):
+    output = bytearray()
+
+    mversion = header.version_id & 0xFFFFFF00
+    patch_id = PATCH if mversion == SCI32_100 else PATCH80
+    output += write_uint16le(patch_id)
+
+    output += write_uint32le(header.version_id)
+    if mversion > SCI_01:
+        output += write_uint16le(0)  # comments_pos
+    if mversion >= SCI_05:
+        output += write_uint16le(header.unk_count)
+
+    str_count = len(lines)
+    output += write_uint16le(str_count)
+
+    unk_b_count1 = 5
+    unk_b_count2 = 9
+    header_size = 10
+
+    if mversion == SCI_01:
+        unk_b_count1 = 2
+        unk_b_count2 = 2
+        header_size = 6
+    elif mversion in {SCI_02_B, SCI_02_C, SCI_02_D}:
+        unk_b_count2 = 8
+        header_size = 8
+
+    for line in lines:
+        if mversion == SCI_01:
+            output += bytes([line['talker'], bytes.fromhex(line['padding'])[0]])
+            output += write_uint16le(0)
+            output += bytes.fromhex(line['padding'][1:])
+        else:
+            meta = bytes([int(x) for x in operator.itemgetter('noun', 'verb', 'condition', 'sequence', 'talker')(line)])
+            assert len(meta) == unk_b_count1
+            output += meta
+            output += write_uint16le(0)
+            assert len(bytes.fromhex(line['padding'])) == unk_b_count2 - unk_b_count1, (line['padding'], unk_b_count2,  unk_b_count1)
+            output += bytes.fromhex(line['padding'])
+
+        has_comments = bool(line['comment_padding'])
+
+    for idx, line in enumerate(lines):
+        currlen = len(output) - 2
+
+        translation = line.get('translation')
+        print(line)
+        if translation is not None:
+            output += translation.replace('\n\n', '\r\n').encode('windows-1255') + b'\0'
+        else:
+            output += line['text'].replace('\n\n', '\r\n').encode(SIERRA_CODEPAGE) + b'\0'
+
+        base_pos = 2+header_size+(idx*(unk_b_count2 + 2)) + unk_b_count1
+        output[base_pos:base_pos+2] = write_uint16le(currlen)
+
+
+    if mversion > SCI_01:
+        comment_pos = len(output) - 8
+        output[6:8] = write_uint16le(comment_pos)
+
+    if has_comments:
+        if mversion == SCI_01:
+            unk_b_count1 = 2
+            unk_b_count2 = 0
+        elif mversion in {SCI_02_B, SCI_02_C, SCI_02_D}:
+            unk_b_count1 = 0
+            unk_b_count2 = 0
+        else:
+            unk_b_count1 = 0
+            unk_b_count2 = 6
+
+        for line in lines:
+            padding = bytes.fromhex(line['comment_padding'])
+            assert len(padding) == unk_b_count2, (len(padding), unk_b_count2)
+            output += padding[:unk_b_count1]
+            output += line['comment_text'].encode(SIERRA_CODEPAGE) + b'\0'
+            output += padding[unk_b_count1:]
+    return bytes(output)
+
+
+def import_messages(gamedir, output, encoding):
+    filenames = list(load_resources(
+        gamedir,
+        patterns=MESSAGE_PATTERNS,
+        # patches=None,
+    ))
+
+    encoding = {
+        'encoding': encoding,
+        'errors': 'surrogateescape',
+    }
+
+    with open(output, 'r', encoding='utf-8', errors='surrogateescape') as text_stream:
+        tsv_reader = csv.DictReader(text_stream, delimiter='\t')
+        grouped = groupby(tsv_reader, key=operator.itemgetter('file'))
+        for tfname, group in grouped:
+            basename = Path(tfname).name
+            group = list(group)
+            print(f'Loading messages for {basename}', file=sys.stderr)
+            for fname in filenames:
+                if fname.name != basename:
+                    continue
+                with fname.open('rb') as stream:
+                    offset = 0
+                    patch_id = read_uint16le(stream)
+
+                    if patch_id in {PATCH, PATCH80}:
+                        offset = 2
+
+                    stream.seek(offset)
+                    header = read_header(stream)
+                    with open(fname.name, 'wb') as out:
+                        out.write(save_msg_file(header, group))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='Exports text from messages files (*.msg) to csv file',
+    )
+    parser.add_argument(
+        'gamedir',
+        help='directory containing the game files',
+    )
+    parser.add_argument(
+        '-i',
+        '--input',
+        default='messages.tsv',
+        help='csv file to export the messages to',
+    )
+    parser.add_argument(
+        '-e',
+        '--encoding',
+        default=SIERRA_CODEPAGE,
+        help='codepage to decode the messages',
+    )
+    args = parser.parse_args()
+
+    import_messages(args.gamedir, args.input, args.encoding)


### PR DESCRIPTION
This allows exporting the messages along with the metadata saved in a special format using TraduSCI for unofficial subtitles patches.
Heavily based on TraduSCI source code from https://erolfi.wordpress.com/tradusci/